### PR TITLE
Reference whole `FluentAssertions` 7.x version

### DIFF
--- a/JsonValidator.FluentAssertions/JsonValidator.FluentAssertions.csproj
+++ b/JsonValidator.FluentAssertions/JsonValidator.FluentAssertions.csproj
@@ -19,8 +19,8 @@
     <PackageId>JsonValidator.FluentAssertions</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.1.4.0</FileVersion>
-    <Version>1.1.4</Version>
+    <FileVersion>1.1.5.0</FileVersion>
+    <Version>1.1.5</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="JsonValidator" Version="1.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
License change of FluentAssertion affects 8.x, while 7.x is still using old license. This change should allow use of newer FluentAssertion versions (e.g. current v7.2) without getting any warning when building projects.

- 8.0.0 release note: https://fluentassertions.com/releases/#800 (license change notice)
- 7.2.0 release note: https://fluentassertions.com/releases/#720 (no license change), https://www.nuget.org/packages/FluentAssertions/7.2.0 (Apache 2.0)